### PR TITLE
Add themed app icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@android:color/black"/>
     <foreground android:drawable="@drawable/ic_foreground_nix"/>
+    <monochrome android:drawable="@drawable/ic_foreground_nix"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@android:color/black"/>
     <foreground android:drawable="@drawable/ic_foreground_nix"/>
+    <monochrome android:drawable="@drawable/ic_foreground_nix"/>
 </adaptive-icon>


### PR DESCRIPTION
This commit implements themed app icon support by reusing the current foreground icon, taking advantage of its monochrome design.

More information on themed app icons:
https://developer.android.com/develop/ui/views/launch/icon_design_adaptive
https://developer.android.com/reference/android/graphics/drawable/AdaptiveIconDrawable