### PR TITLE
feat: allow bootstrap install from non-https servers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="false"
         android:theme="@style/Theme.TermuxApp.DayNight.DarkActionBar"
+        android:usesCleartextTraffic="true"
         tools:targetApi="m">
 
         <activity


### PR DESCRIPTION
Fixes https://github.com/nix-community/nix-on-droid/issues/508